### PR TITLE
Fix /arc-sw.js url path

### DIFF
--- a/trunk/arc.php
+++ b/trunk/arc.php
@@ -43,7 +43,7 @@ function arc_reverse_proxy () {
     $method = $_SERVER['REQUEST_METHOD'];
     $path = strtok($_SERVER["REQUEST_URI"], '?');
     $SW_PROXY_PATH = '/arc-sw.js';
-    $WIDGET_PROXY_PATH = '/widget.js';
+    $WIDGET_PROXY_PATH = '/arc-widget';
 
     if (in_array($method, ['GET', 'HEAD'])) {
         if ($path === $SW_PROXY_PATH) {

--- a/trunk/arc.php
+++ b/trunk/arc.php
@@ -43,7 +43,7 @@ function arc_reverse_proxy () {
     $method = $_SERVER['REQUEST_METHOD'];
     $path = strtok($_SERVER["REQUEST_URI"], '?');
     $SW_PROXY_PATH = '/arc-sw.js';
-    $WIDGET_PROXY_PATH = '/arc-widget';
+    $WIDGET_PROXY_PATH = '/widget.js';
 
     if (in_array($method, ['GET', 'HEAD'])) {
         if ($path === $SW_PROXY_PATH) {

--- a/trunk/arc.php
+++ b/trunk/arc.php
@@ -42,7 +42,7 @@ function arc_reverse_proxy () {
     $WIDGET_ORIGIN = 'https://arc.io';
     $method = $_SERVER['REQUEST_METHOD'];
     $path = strtok($_SERVER["REQUEST_URI"], '?');
-    $SW_PROXY_PATH = '/arc-sw';
+    $SW_PROXY_PATH = '/arc-sw.js';
     $WIDGET_PROXY_PATH = '/arc-widget';
 
     if (in_array($method, ['GET', 'HEAD'])) {


### PR DESCRIPTION
Changed the `/arc-sw` to `/arc-sw.js` so the service worker can be hosted correctly and as expected

For issue https://github.com/Arc-io/Widget-WordPress-Plugin/issues/4